### PR TITLE
fix: close unclosed file handles in consensus module

### DIFF
--- a/src/svirlpool/analysis/get_local_signal_stats.py
+++ b/src/svirlpool/analysis/get_local_signal_stats.py
@@ -23,8 +23,8 @@ def parse_region(region: str) -> tuple[str, int, int]:
 def parse_alignments(
     path_alignments: PosixPath, region: tuple[str, int, int]
 ) -> list[pysam.AlignedSegment]:
-    bamfile = pysam.AlignmentFile(path_alignments, "rb")
-    return list(bamfile.fetch(*region))
+    with pysam.AlignmentFile(path_alignments, "rb") as bamfile:
+        return list(bamfile.fetch(*region))
 
 
 # parse breakends to tuples start, end, size (ref coordinates)


### PR DESCRIPTION
- Wrap pysam.AlignmentFile operations in context managers to ensure proper closure
- Fix consensus.py: subsample_alignments, final_consensus, align_cutreads_to_representative, consensus_while_clustering, add_unaligned_reads_to_consensuses_inplace
- Fix util.py: load_alignments, get_alignments, get_alignments_to_reference, create_sample_dict_from_alignments, cut_alignments, cut_alignments_in_regions
- Fix get_local_signal_stats.py: parse_alignments
- Prevents file descriptor leaks in workflow